### PR TITLE
Vbscore v2

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "type": "chrome",
+            "request": "launch",
+            "name": "Launch Chrome against localhost",
+            "url": "http://localhost:8080",
+            "webRoot": "${workspaceFolder}"
+        }
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # vbscore
 this web app is a javascript/css learning experiment
 value is that I've never found an ios app with the ability to switch between rally and sideout scoring
+
+Plan on including the ability to change team names

--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
                     <button onclick="adjustScore('B', 1)">+</button>
                 </div>
             </div>
-            <input type="text" id="team1" placeholder="Team A" onchange="updateTeamAName">
-            <input type="text" id="team2" placeholder="Team B" onchange="updateTeamBName">
+            <input type="text" id="team1" placeholder="Team A" onchange="updateTeamAName()">
+            <input type="text" id="team2" placeholder="Team B" onchange="updateTeamBName()">
             <button onclick="resetScores()">Reset</button>
         </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -35,8 +35,8 @@
                     <button onclick="adjustScore('B', 1)">+</button>
                 </div>
             </div>
-            <input type="text" id="team1" placeholder="Team A" onchange="updateTeamAName()">
-            <input type="text" id="team2" placeholder="Team B" onchange="updateTeamBName()">
+            <input type="text" id="team1" placeholder="Team A" oninput="updateTeamAName()">
+            <input type="text" id="team2" placeholder="Team B" oninput="updateTeamBName()">
             <button onclick="resetScores()">Reset</button>
         </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -9,15 +9,29 @@ let teamAName = "Team 1";
 let teamBName = "Team 2";
 //let servingTeam = null; /* 'A';   null for now and assumes we don't know who is serving */
 let strScoreType = document.getElementById('scoringType').value;
+let isSwitched = false; // used to track if the teams have been switched
 
 
 function updateTeamNames() {
-   //document.querySelector('input[name="team1"]').innerHTML    = teamAName;
    document.getElementsByName('team1')[0].innerHTML = teamAName;
    document.getElementsByName('team2')[0].innerHTML = teamBName;
 }
 // set the default team names using the global variables
 updateTeamNames();
+
+function updateTeamAName() {
+    const input = document.getElementById('team1');
+    teamAName = input.value || 'Team 1';
+    updateTeamNames();
+    saveState();
+}
+
+function updateTeamBName() {
+    const input = document.getElementById('team2');
+    teamBName = input.value || 'Team 2';
+    updateTeamNames();
+    saveState();
+}
 
 
 function setScoring() {
@@ -67,6 +81,13 @@ function increaseScore(team) {
            servingTeam = teamB_serve;
         }
    }
+
+   // Set focus to the correct button to trigger :focus underline
+   if (team === 'A') {
+       document.getElementById('scoreA').focus();
+   } else if (team === 'B') {
+       document.getElementById('scoreB').focus();
+   }
   
    //if (team === 'A') {
    //    scoreA++;
@@ -82,8 +103,8 @@ function increaseScore(team) {
    //    servingTeam = 'B'; /* used for sideout */
    //}
    //console.log(servingTeam);
-
-
+   
+    saveState();
 }
 
 
@@ -119,6 +140,7 @@ function resetScores() {
    document.getElementById('adjustScoreA').innerText = scoreA;
    document.getElementById('adjustScoreB').innerText = scoreB;
    servingTeam = null;
+   saveState();
 }
 
 
@@ -133,12 +155,15 @@ function adjustScore(team, amount) {
        document.querySelector('#scoreB span').innerText = scoreB;
        document.getElementById('adjustScoreB').innerText = scoreB;
    }
+   saveState();
 }
 
 
 function switchDivs() {
    let container = document.getElementsByClassName('container')[0];
    container.appendChild(container.children[0]);
+   isSwitched = !isSwitched;
+   saveState();
    //console.log('switchted!');
   
    // this section is needed to make the underline appear on the right button after the switch
@@ -150,5 +175,61 @@ function switchDivs() {
        document.getElementById("scoreB").focus();
        //console.log("should be B - " + servingTeam);
    }
+   saveState();
 }
 
+// Allow closing menu by clicking outside the menu content
+document.getElementById('menuOverlay').addEventListener('click', function(event) {
+    if (event.target === this) {
+        toggleMenu();
+    }
+});
+
+
+// Load saved state from localStorage
+function saveState() {
+    localStorage.setItem('vbscore_state', JSON.stringify({
+        scoreA,
+        scoreB,
+        teamAName,
+        teamBName,
+        servingTeam,
+        scoringType: document.getElementById('scoringType').value,
+        isSwitched
+    }));
+}
+
+document.getElementById('scoringType').addEventListener('change', saveState);
+
+function loadState() {
+    const state = JSON.parse(localStorage.getItem('vbscore_state'));
+    if (state) {
+        scoreA = state.scoreA || 0;
+        scoreB = state.scoreB || 0;
+        teamAName = state.teamAName || "Team 1";
+        teamBName = state.teamBName || "Team 2";
+        servingTeam = state.servingTeam || 0;
+        document.getElementById('scoringType').value = state.scoringType || 'sideout';
+        isSwitched = state.isSwitched || false;
+    }
+}
+
+loadState();
+updateTeamNames();
+document.querySelector('#scoreA span').innerText = scoreA;
+document.querySelector('#scoreB span').innerText = scoreB;
+document.getElementById('adjustScoreA').innerText = scoreA;
+document.getElementById('adjustScoreB').innerText = scoreB;
+
+// Restore underline to the last serving team after loading state
+if (servingTeam == teamA_serve) {
+    document.getElementById("scoreA").focus();
+} else if (servingTeam == teamB_serve) {
+    document.getElementById("scoreB").focus();
+}
+
+if (isSwitched == true) {
+    switchDivs();
+    isSwitched = true;
+    saveState();
+}

--- a/script.js
+++ b/script.js
@@ -13,8 +13,10 @@ let isSwitched = false; // used to track if the teams have been switched
 
 
 function updateTeamNames() {
-   document.getElementsByName('team1')[0].innerHTML = teamAName;
-   document.getElementsByName('team2')[0].innerHTML = teamBName;
+    document.getElementsByName('team1')[0].innerHTML = teamAName;
+    document.getElementsByName('team2')[0].innerHTML = teamBName;
+    document.getElementById('team1').value = teamAName; // Set input value
+    document.getElementById('team2').value = teamBName; // Set input value
 }
 // set the default team names using the global variables
 updateTeamNames();

--- a/script.js
+++ b/script.js
@@ -5,32 +5,41 @@ let scoreB = 0;
 const teamA_serve = 1;
 const teamB_serve = 2;
 let servingTeam = 0;
-let teamAName = "Team 1";
-let teamBName = "Team 2";
+let teamAName = "";
+let teamBName = "";
 //let servingTeam = null; /* 'A';   null for now and assumes we don't know who is serving */
 let strScoreType = document.getElementById('scoringType').value;
 let isSwitched = false; // used to track if the teams have been switched
 
 
 function updateTeamNames() {
-    document.getElementsByName('team1')[0].innerHTML = teamAName;
-    document.getElementsByName('team2')[0].innerHTML = teamBName;
-    document.getElementById('team1').value = teamAName; // Set input value
-    document.getElementById('team2').value = teamBName; // Set input value
+    document.getElementsByName('team1')[0].innerHTML = teamAName || "Team A";
+    document.getElementsByName('team2')[0].innerHTML = teamBName || "Team B";
+    document.getElementById('team1').value = teamAName;
+    document.getElementById('team2').value = teamBName;
+
 }
 // set the default team names using the global variables
 updateTeamNames();
 
 function updateTeamAName() {
     const input = document.getElementById('team1');
-    teamAName = input.value || 'Team 1';
+    if (input.value.trim() === "") {
+        teamAName = "";
+    } else {
+        teamAName = input.value;
+    }
     updateTeamNames();
     saveState();
 }
 
 function updateTeamBName() {
     const input = document.getElementById('team2');
-    teamBName = input.value || 'Team 2';
+    if (input.value.trim() === "") {
+        teamBName = "";
+    } else {
+        teamBName = input.value;
+    }
     updateTeamNames();
     saveState();
 }
@@ -208,8 +217,8 @@ function loadState() {
     if (state) {
         scoreA = state.scoreA || 0;
         scoreB = state.scoreB || 0;
-        teamAName = state.teamAName || "Team 1";
-        teamBName = state.teamBName || "Team 2";
+        teamAName = state.teamAName || "";
+        teamBName = state.teamBName || "";
         servingTeam = state.servingTeam || 0;
         document.getElementById('scoringType').value = state.scoringType || 'sideout';
         isSwitched = state.isSwitched || false;

--- a/styles.css
+++ b/styles.css
@@ -36,7 +36,7 @@ html, body {
 }
 
 .menu-content {
-    background: white;
+/*    background: white;
     padding: 20px;
     border-radius: 10px;
     text-align: center;
@@ -44,12 +44,35 @@ html, body {
     max-width: 200px;
     display: flex;
     flex-direction: column;
+    gap: 20px;*/
+    position: relative;
+    background: white;
+    padding: 40px 20px 20px 20px; /* More top padding for the X */
+    border-radius: 10px;
+    text-align: center;
+    width: 90vw;
+    max-width: 250px;
+    max-height: 80vh;
+    display: flex;
+    flex-direction: column;
     gap: 20px;
+    overflow-y: auto; /* Allow scrolling if needed */
+    box-sizing: border-box;
+    align-items: center;
+    justify-content: flex-start;
 }
 
 .menu-header {
+    /*display: flex;
+    justify-content: flex-end; */
+    width: 100%;
     display: flex;
     justify-content: flex-end;
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 10px 20px 0 0;
+    box-sizing: border-box;
 }
 
 .menu-close {
@@ -154,4 +177,33 @@ html, body {
     background-color: purple;
 */
     z-index: 8;
+}
+
+/*Drop down menu for Side Out vs Rally*/
+#scoringType {
+    width: 100%;
+    max-width: 150px; /* Adjust as needed */
+    margin: 0 auto 10px auto;
+    font-size: 1em;
+    padding: 6px 10px;
+    box-sizing: border-box;
+    display: block;
+}
+
+/* Input fields for team names */
+#team1,
+#team2 {
+    width: 80%;           /* Make input fields narrower */
+    max-width: 180px;     /* Prevent them from being too wide */
+    min-width: 100px;     /* Optional: set a minimum width */
+    height: 44px;         /* Increase height */
+    font-size: 1.2em;     /* Increase font size */
+    padding: 6px 12px;    /* Optional: add padding for better appearance */
+    margin-bottom: 10px;  /* Optional: space between fields */
+    border-radius: 6px;   /* Optional: rounded corners */
+    border: 1px solid #ccc; /* Optional: subtle border */
+    box-sizing: border-box;
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
 }


### PR DESCRIPTION
Fixes:

Menu Changes:
- Can now exit menu by clicking anywhere outside of the menu box as well as the X in the top right of the menu
- Increased the width of the menu
- Increased the height of the Side Out vs Rally drop down menu
- Increased the height, font, and appearance of team name text boxes
- made the Reset button smaller
- When on mobile, you can scroll down on the menu if you can't see the whole thing in landscape mode

Save/Load States (things that remain saved between refreshing the website):
- Score when increased on main page
- Score when increased/decreased in menu
- Score when reset in menu
- Team Names
- Lines under the last team name/ score who scored
- Side Out vs Rally Scoring
- The side that each team was on


Team Names are now:
- Displayed in the text box to edit them (it now displays the team name in each respective box rather than a blank box with a gray "Team A" or "Team B"
- As you type in the names of the teams, it gives live updates in the main screen of the app, so as you type you can see the names change on the main page.


There was an issue when updating the team name where it would snap to "Team 1" or "Team 2" (respectively) when  deleting the team names, and now it shows the gray text for "Team A" or "Team B" respectively, and it is actually an empty text box.